### PR TITLE
Wip : Fix - Total des sous-totaux incorrecte avec altapdf

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -941,12 +941,12 @@ class ActionsSubtotal
                 }
                 else
                 {
-			if ($l->product_type != 9) {
-                    		$total += $l->total_ht;
-                    		$total_tva += $l->total_tva;
-                    		$TTotal_tva[$l->tva_tx] += $l->total_tva;
-                    		$total_ttc += $l->total_ttc;
-			}
+					if ($l->product_type != 9) {
+						$total += $l->total_ht;
+						$total_tva += $l->total_tva;
+						$TTotal_tva[$l->tva_tx] += $l->total_tva;
+						$total_ttc += $l->total_ttc;
+					}
                 }
             }
 		}

--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -1101,7 +1101,7 @@ class ActionsSubtotal
 
 					$TInfo = $this->getTotalLineFromObject($object, $line, '', 1);
 					$TTotal_tva = $TInfo[3];
-					$total_to_print = price($TInfo[0]);
+					$total_to_print = price($TInfo[2] - $TInfo[1]);
 
                     $line->total_ht = $TInfo[0];
 					$line->total = $TInfo[0];


### PR DESCRIPTION
TS2401-1944
Les sous totaux affichent sur le pdf altairis le total HT de location et vente + le total des lignes de location ou de vente selon le sous total concerné
Pour le total des deux premières lignes au lieu d'avoir 75 (60 + 15) on obtient 936,40 qui est égal au total HT de 861,40 + 75

Avant correction
![image](https://github.com/altairisfr/subtotal/assets/91946767/83ea1dbc-cd87-4cc1-8288-0509e9d78bb5)
![image](https://github.com/altairisfr/subtotal/assets/91946767/1f40864c-2f3d-481d-a1f9-a3435bff5c6b)

Après correction
![image](https://github.com/altairisfr/subtotal/assets/91946767/d9cb251e-dc33-4f7d-bcde-0b56bea64925)

Dans le code 
action_subtotal.class.php
fonction pdf_add_total
$TInfo vaut l'appel de la fonction getTotalLineFromObject renvoyant les sous-totaux de vente et de location, suite à quoi on obtient un tableau avec le total des lignes de location en ht ($TInfo[0]), puis la tva ($TInfo[1]), puis le ttc ($TInfo[2]).
Hors avec notre modèle de pdf on obtient en ht un chiffre erroné alors qu'avec le modèle azur et cyan on obtient le bon ht.
J'ai donc fait un print du montant ttc - le montant de la tva ($TInfo[2] - $TInfo[1])  pour avoir le bon montant ht, au lieu de print sur le montant ht ($TInfo[0]).
Les modèle du core ne sont apparemment pas affecté par cette modif
